### PR TITLE
MTGetArrayJoinの修正

### DIFF
--- a/plugins/GetHashVar/lib/GetHashVar/Tags.pm
+++ b/plugins/GetHashVar/lib/GetHashVar/Tags.pm
@@ -457,7 +457,7 @@ sub _hdlr_array_join {
     my $array = $ctx->stash( 'vars' )->{ $name };
     $array = $ctx->stash( 'vars' )->{ lc ( $name ) } unless $array;
     if ( ( ref $array ) eq 'ARRAY' ) {
-        return join( $glue, $array );
+        return join( $glue, @$array );
     }
     return '';
 }

--- a/plugins/GetHashVar/lib/GetHashVar/Tags.pm
+++ b/plugins/GetHashVar/lib/GetHashVar/Tags.pm
@@ -453,7 +453,7 @@ sub _hdlr_get_hash_key {
 sub _hdlr_array_join {
     my ( $ctx, $args, $cond ) = @_;
     my $name = $args->{ 'name' } || return '';
-    my $glue  = $args->{ 'glue ' } || '';
+    my $glue  = $args->{ 'glue' } || '';
     my $array = $ctx->stash( 'vars' )->{ $name };
     $array = $ctx->stash( 'vars' )->{ lc ( $name ) } unless $array;
     if ( ( ref $array ) eq 'ARRAY' ) {


### PR DESCRIPTION
2点修正いたしましたので、ご確認の程お願いいたします。
- 返値がARRAYとなる
- `glue`が適用されない
